### PR TITLE
Added CSS to fix bg

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -9,6 +9,7 @@ html {
     margin: 0px;
     background-image: url('https://www.pe.se/sites/default/files/angstrom_jstrongphoto_web_01.jpg');
     background-repeat: no-repeat;
+    background-size: cover;
     background-attachment: fixed;
     backdrop-filter: blur(5px);
   }


### PR DESCRIPTION
The background is really wonky on a 1440p monitor.
how to replicate: get 1440p monitor, oops!

This fix should work for any scale display, while not changing how it looks on lower resolutions. (Or more zoomed in/zoomed out)